### PR TITLE
Filter products by category

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -83,7 +83,11 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        if len(ratings) > 0:
+            avg = total_rating / len(ratings)
+        else:
+            avg = 0
+
         return avg
 
     class Meta:

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -83,11 +83,7 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        if len(ratings) > 0:
-            avg = total_rating / len(ratings)
-        else:
-            avg = 0
-
+        avg = total_rating / len(ratings)
         return avg
 
     class Meta:

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -19,7 +19,7 @@ class ProductSerializer(serializers.ModelSerializer):
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
                   'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                  'average_rating', 'can_be_rated', 'category')
         depth = 1
 
 
@@ -94,13 +94,15 @@ class Products(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         new_product.customer = customer
 
-        product_category = ProductCategory.objects.get(pk=request.data["category_id"])
+        product_category = ProductCategory.objects.get(
+            pk=request.data["category_id"])
         new_product.category = product_category
 
         if "image_path" in request.data:
             format, imgstr = request.data["image_path"].split(';base64,')
             ext = format.split('/')[-1]
-            data = ContentFile(base64.b64decode(imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
+            data = ContentFile(base64.b64decode(
+                imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
 
             new_product.image_path = data
 
@@ -152,7 +154,8 @@ class Products(ViewSet):
         """
         try:
             product = Product.objects.get(pk=pk)
-            serializer = ProductSerializer(product, context={'request': request})
+            serializer = ProductSerializer(
+                product, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
@@ -182,7 +185,8 @@ class Products(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         product.customer = customer
 
-        product_category = ProductCategory.objects.get(pk=request.data["category_id"])
+        product_category = ProductCategory.objects.get(
+            pk=request.data["category_id"])
         product.category = product_category
         product.save()
 
@@ -285,7 +289,8 @@ class Products(ViewSet):
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)
-            rec.customer = Customer.objects.get(user__id=request.data["recipient"])
+            rec.customer = Customer.objects.get(
+                user__id=request.data["recipient"])
             rec.product = Product.objects.get(pk=pk)
 
             rec.save()


### PR DESCRIPTION
This PR implements the filtering of products by category in the backend, so that the front end has the information it needs to display the correct products in the filter

## Changes

- Added category to product serializer, since the depth was already set to 1, both the category id and name should come back in the response
- A bunch of other auto-formatting stuff happened

## Requests / Responses

The shape of _/products_ is different now that category has been added in

**Request**

GET `/products` Gets all products

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 1,
    "name": "Optima",
    "price": 1655.15,
    "number_sold": 0,
    "description": "2008 Kia",
    "quantity": 3,
    "created_date": "2019-05-21",
    "location": "Seoul",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 0,
    "category": {
      "id": 2,
      "name": "Auto"
    }
  },
```

## Testing

- Run GET /products to verify new shape of products object that is returned in the response

To test the entire feature:
1. Start up the front end and back end dev servers
2. Navigate to /products on the front end
3. Click the "Filter Products" button
4. Click the "Filter by Category" dropdown
5. The 3 categories for the products should appear, in this case Auto, Clothes, and Tools
6. Click one of the categories, then click the green "Filter" button
7. Only the products that have the category chosen should appear


## Related Issues

- Fixes #9