### PR TITLE
fix: minimum items sold request now functions correctly

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -272,7 +272,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In views/product.py, what should have been a `>=` operator was mistakenly input as `<=` causing the bug. This has been corrected.

## Requests / Responses

**Request**

GET /products?number_sold=1

**Response**

HTTP/1.1 200 OK

```json
[
  {
    "id": 45,
    "name": "Optima",
    "price": 1655.15,
    "number_sold": 1,
    "description": "2008 Kia",
    "quantity": 3,
    "created_date": "2019-05-21",
    "location": "Toronto",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 0,
    "category": {
      "id": 2,
      "name": "Auto"
    }
  },
  {
    "id": 50,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 2,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Berlin",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 3.25,
    "category": {
      "id": 2,
      "name": "Auto"
    }
  }
]
```

## Testing

- Using Yaak:
- Run a GET request to http://localhost:8000/products?number_sold=2
- If using default database fixtures there should be 2 entries; else nothing with a number_sold lower than 2 should be shown
- Run a GET request to http://localhost:8000/products?number_sold=1
- Verify that there are 2 entries (using default fixtures) with nothing shown with a number_sold lower than 1
- Verify that number_sold=0 returns all entries and numbers_sold=3 returns an empty array


## Related Issues

- Fixes #32