### PR TITLE
Bugfix - Products added to last closed order (issue #35)

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -15,7 +15,7 @@ router.register(r"customers", Customers, "customer")
 router.register(r"users", Users, "user")
 router.register(r"orders", Orders, "order")
 router.register(r"cart", Cart, "cart")
-router.register(r"payment-types", Payments, "payment")
+router.register(r"paymenttypes", Payments, "payment")
 router.register(r"profile", Profile, "profile")
 router.register(r"stores", Stores, "store")
 

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -15,7 +15,7 @@ router.register(r"customers", Customers, "customer")
 router.register(r"users", Users, "user")
 router.register(r"orders", Orders, "order")
 router.register(r"cart", Cart, "cart")
-router.register(r"paymenttypes", Payments, "payment")
+router.register(r"payment-types", Payments, "payment")
 router.register(r"profile", Profile, "profile")
 router.register(r"stores", Stores, "store")
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -24,6 +24,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('id', 'product')
         depth = 1
 
+
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
@@ -35,7 +36,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        fields = ('id', 'url', 'created_date',
+                  'payment_type', 'customer', 'lineitems')
 
 
 class Orders(ViewSet):
@@ -104,7 +106,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type_id = request.data["payment_type"]
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
@@ -150,3 +152,9 @@ class Orders(ViewSet):
             orders, many=True, context={'request': request})
 
         return Response(json_orders.data)
+
+    @action(methods=['put'], detail=True, url_path='complete')
+    def complete(self, request, pk=None):
+        """Complete the order (PUT request on the order updating the payment type)"""
+        # TODO: Add more to this for additional order completion logic
+        return self.update(request, pk)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -97,7 +97,6 @@ class Profile(ViewSet):
         """Shopping cart manipulation"""
 
         current_user = Customer.objects.get(user=request.auth.user)
-        print(f"{current_user} is the current_user")
 
         if request.method == "DELETE":
             """


### PR DESCRIPTION
## Changes

#### views/order.py
- When updating an order, changed name of data being stored from `payment_type` to `payment_type_id` to match seed data
- Added complete method for the orders/{orderId}/complete endpoint from frontend (for now it just updates the order's payment id, but in the future we can put more logic in here for closing an order)
#### views/product.py
- Added `add_to_order` method for front end to be able to add products to an order
#### views/profile.py
- Made sure the cart methods are getting the correct open order, if one exists

## Requests / Responses

No new requests, but **POST add item to cart**, **GET shopping cart**, **GET orders**, and **PUT orders** in Yaak should all work


## Testing

- Switch to this branch as well as the front end branch for this issue
- Create a payment type
- Add products to your cart
- Select complete order, select the newly created payment method, then click "complete order"
- Go back to products page, make a new cart, and complete the order again
- (The my orders page is empty, but this is a separate ticket)


## Related Issues

- Fixes #35