### PR TITLE
Bugfix/remove item from cart/#31

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,8 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
+            
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
# Fix Cart Item Removal Functionality

## Description
This PR resolves the customer complaint about being unable to remove items from their shopping cart. The issue was in the LineItems ViewSet's `destroy` method, which was missing the actual deletion of the OrderProduct record.

## Changes
- Added `order_product.delete()` call in LineItems ViewSet destroy method
- Updated client-side `removeProductFromOrder` function to use correct endpoint (`cart/:id`)

## Requests / Responses

**Request**
DELETE `/lineitems/1` Removes a line item from user's cart
```
Headers:
Authorization: Token 9ba45f09651c5b0c404f37a2d2572c026c146611
```

**Response - Success**
HTTP/1.1 204 No Content
```json
{}
```

**Response - Line item not found**
HTTP/1.1 404 Not Found
```json
{
    "message": "OrderProduct matching query does not exist."
}
```

**Response - Not authorized**
HTTP/1.1 404 Not Found
```json
{
    "message": "OrderProduct matching query does not exist."
}
```

## Testing
- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database with test data
- [ ] Create user account and authenticate
- [ ] Add products to cart via POST `/cart`
- [ ] Get cart contents via GET `/cart` to obtain line item IDs
- [ ] Remove item from cart via DELETE `/lineitems/:id`
- [ ] Verify item is removed from cart
- [ ] Test error cases (non-existent line item, unauthorized access)

## Related Issues
- Fixes cart item removal customer complaints
- Resolves 404 errors when attempting to delete line items