### PR TITLE
Feautre/get products by loc/24

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -39,6 +39,7 @@ class Product(SafeDeleteModel):
         width_field=None,
         max_length=None,
         null=True,
+        blank=True,
     )
 
     @property

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -121,7 +121,6 @@ class Products(ViewSet):
             )
 
             new_product.image_path = data
-            
         new_product.full_clean()
         new_product.save()
 
@@ -271,6 +270,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
         min_price = self.request.query_params.get("min_price", None)
+        location = self.request.query_params.get("location", None)
 
         if order is not None:
             order_filter = order
@@ -286,6 +286,9 @@ class Products(ViewSet):
 
         if min_price is not None:
             products = products.filter(price__gte=float(min_price))
+
+        if location is not None:
+            products = products.filter(location__icontains=location)
 
         if quantity is not None:
             products = products.order_by("-created_date")[: int(quantity)]

--- a/tests/product.py
+++ b/tests/product.py
@@ -168,6 +168,81 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), 1)  # Should return 1 product (200.00)
         self.assertEqual(json_response[0]["price"], 200.00)
 
+    def test_filter_products_by_location(self):
+        """
+        Ensure we can filter products by location using contains search.
+        """
+        # Create products with different locations
+        url = "/products"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+
+        # Create product in Pittsburgh
+        data = {
+            "name": "Pittsburgh Kite",
+            "price": 25.99,
+            "quantity": 50,
+            "description": "Kite from Steel City",
+            "category_id": 1,
+            "location": "Pittsburgh, PA",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Create product in New York
+        data = {
+            "name": "NYC Kite",
+            "price": 35.99,
+            "quantity": 30,
+            "description": "Big city kite",
+            "category_id": 1,
+            "location": "New York, NY",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Create product in Los Angeles
+        data = {
+            "name": "LA Kite",
+            "price": 29.99,
+            "quantity": 40,
+            "description": "West coast kite",
+            "category_id": 1,
+            "location": "Los Angeles, CA",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Test filtering by location containing "Pittsburgh"
+        url = "/products?location=Pittsburgh"
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)  # Should return 1 product
+        self.assertIn("Pittsburgh", json_response[0]["location"])
+
+        # Test filtering by location containing "New York" (case insensitive)
+        url = "/products?location=new york"
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)  # Should return 1 product
+        self.assertIn("New York", json_response[0]["location"])
+
+        # Test filtering by partial location "CA" (should get Los Angeles)
+        url = "/products?location=CA"
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)  # Should return 1 product
+        self.assertIn("CA", json_response[0]["location"])
+
+        # Test filtering by non-existent location
+        url = "/products?location=NonExistentCity"
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)  # Should return no products
+
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
This PR implements location filtering for the products endpoint using Django's `__icontains` lookup mechanism.

## Changes

**bangazonapi/views/product.py**
- Added `location` query parameter extraction
- Implemented `location__icontains` filtering for case-insensitive partial matching

**bangazonapi/models/product.py**
- Added `blank=True` to `image_path` field to fix validation issues

**tests/product.py**
- Added `test_filter_products_by_location()` method with test coverage

## Testing

- `git fetch origin` to fetch new branches
- `git switch feautre/get-products-by-loc/24` switch to this branch  
- `poetry run python manage.py test tests.product -v 1` to run tests and verify that they pass
- Test endpoint manually: `GET /products?location=Pittsburgh`

## Related Issues

Fixes #24